### PR TITLE
adjust LED timings; switch to HTTP/POST; add SCREEN blink support

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -894,6 +894,27 @@ void Screen::handleStartBluetoothPinScreen(uint32_t pin)
     setFastFramerate();
 }
 
+void Screen::blink() {
+    setFastFramerate();
+    uint8_t count = 10;
+    uint8_t blinker = 0;
+
+    dispdev.setBrightness(254);
+
+    while(count>0) {
+        if (blinker == 254) {
+            blinker = 0;
+            count--;
+        } else {
+            blinker++;
+        }
+        int width = blinker / (254.00 / SCREEN_WIDTH);
+        dispdev.fillRect(0, 0, width, SCREEN_HEIGHT);
+        dispdev.display();
+    }
+     dispdev.setBrightness(brightness);
+}
+
 void Screen::handlePrint(const char *text)
 {
     DEBUG_MSG("Screen: %s", text);

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -897,20 +897,15 @@ void Screen::handleStartBluetoothPinScreen(uint32_t pin)
 void Screen::blink() {
     setFastFramerate();
     uint8_t count = 10;
-    uint8_t blinker = 0;
-
     dispdev.setBrightness(254);
-
     while(count>0) {
-        if (blinker == 254) {
-            blinker = 0;
-            count--;
-        } else {
-            blinker++;
-        }
-        int width = blinker / (254.00 / SCREEN_WIDTH);
-        dispdev.fillRect(0, 0, width, SCREEN_HEIGHT);
+        dispdev.fillRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
         dispdev.display();
+        delay(50);
+        dispdev.clear();
+        dispdev.display();
+        delay(50);
+        count = count -1;
     }
      dispdev.setBrightness(brightness);
 }

--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -107,6 +107,8 @@ class Screen : public concurrency::OSThread
      */
     void doDeepSleep();
 
+    void blink();
+
     /// Handles a button press.
     void onPress() { enqueueCmd(ScreenCmd{.cmd = Cmd::ON_PRESS}); }
 

--- a/src/meshwifi/meshhttp.cpp
+++ b/src/meshwifi/meshhttp.cpp
@@ -244,7 +244,7 @@ void initWebServer()
     ResourceNode *node404 = new ResourceNode("", "GET", &handle404);
     ResourceNode *nodeFormUpload = new ResourceNode("/upload", "POST", &handleFormUpload);
     ResourceNode *nodeJsonScanNetworks = new ResourceNode("/json/scanNetworks", "GET", &handleScanNetworks);
-    ResourceNode *nodeJsonBlinkLED = new ResourceNode("/json/blink", "GET", &handleBlinkLED);
+    ResourceNode *nodeJsonBlinkLED = new ResourceNode("/json/blink", "POST", &handleBlinkLED);
     ResourceNode *nodeJsonSpiffsBrowseStatic = new ResourceNode("/json/spiffs/browse/static/", "GET", &handleSpiffsBrowseStatic);
 
     // Secure nodes
@@ -984,14 +984,14 @@ void handleBlinkLED(HTTPRequest *req, HTTPResponse *res)
     res->println("\"status\": \"ok\"");
     res->println("}");
 
-    uint8_t count = 50;
+    uint8_t count = 10;
 
     while (count > 0)
     {
         setLed(true);
-        delay(10);
+        delay(50);
         setLed(false);
-        delay(10);
+        delay(50);
         count = count - 1;
     }
 }

--- a/src/meshwifi/meshhttp.cpp
+++ b/src/meshwifi/meshhttp.cpp
@@ -979,9 +979,7 @@ void handleBlinkLED(HTTPRequest *req, HTTPResponse *res)
     res->setHeader("Content-Type", "application/json");
 
     ResourceParameters *params = req->getParams();
-    std::string blink_target;
-    HTTPBodyParser *parser;
-   
+    std::string blink_target; 
 
     if (! params->getQueryParameter("blink_target", blink_target)) {
         // if no blink_target was supplied in the URL parameters of the 

--- a/src/meshwifi/meshhttp.cpp
+++ b/src/meshwifi/meshhttp.cpp
@@ -978,26 +978,14 @@ void handleBlinkLED(HTTPRequest *req, HTTPResponse *res)
 {
     res->setHeader("Content-Type", "application/json");
 
-    // This can be cleaned up at some point to make it non-blocking and to allow for more configuration.
-    std::string contentType = req->getHeader("Content-Type");
+    ResourceParameters *params = req->getParams();
     std::string blink_target;
     HTTPBodyParser *parser;
    
 
-    if (contentType.rfind("multipart/form-data",0) == 0) {
-        // If a body was submitted to /blink, then figure out whether the user 
-        // watned to blink the LED or the screen
-        parser = new HTTPMultipartBodyParser(req);
-        while (parser->nextField()) {
-            std::string name = parser->getFieldName();
-            if (name  == "blink_target") {
-                char buf[512];
-                size_t readLength = parser->read((byte *)buf, 512);
-                // filename = std::string("/public/") + std::string(buf, readLength);
-                blink_target = std::string(buf, readLength);
-            }
-        }
-    } else {
+    if (! params->getQueryParameter("blink_target", blink_target)) {
+        // if no blink_target was supplied in the URL parameters of the 
+        // POST request, then assume we should blink the LED
        blink_target = "LED";
     }
 
@@ -1017,7 +1005,7 @@ void handleBlinkLED(HTTPRequest *req, HTTPResponse *res)
     }
 
     res->println("{");
-    res->println("\"status\": \"Blink completed: LED\"");
+    res->println("\"status\": \"ok\"");
     res->println("}");
 }
 

--- a/src/meshwifi/meshhttp.cpp
+++ b/src/meshwifi/meshhttp.cpp
@@ -979,27 +979,25 @@ void handleBlinkLED(HTTPRequest *req, HTTPResponse *res)
     res->setHeader("Content-Type", "application/json");
 
     ResourceParameters *params = req->getParams();
-    std::string blink_target; 
+    std::string blink_target;
 
-    if (! params->getQueryParameter("blink_target", blink_target)) {
-        // if no blink_target was supplied in the URL parameters of the 
+    if (!params->getQueryParameter("blink_target", blink_target)) {
+        // if no blink_target was supplied in the URL parameters of the
         // POST request, then assume we should blink the LED
-       blink_target = "LED";
+        blink_target = "LED";
     }
 
-    if (blink_target == "LED" ) {
+    if (blink_target == "LED") {
         uint8_t count = 10;
-        while (count > 0)
-        {
+        while (count > 0) {
             setLed(true);
             delay(50);
             setLed(false);
             delay(50);
             count = count - 1;
         }
-    }
-    else {
-         screen->blink();
+    } else {
+        screen->blink();
     }
 
     res->println("{");

--- a/src/meshwifi/meshhttp.cpp
+++ b/src/meshwifi/meshhttp.cpp
@@ -986,14 +986,16 @@ void handleBlinkLED(HTTPRequest *req, HTTPResponse *res)
 
     uint8_t count = 10;
 
-    while (count > 0)
+    /*while (count > 0)
     {
         setLed(true);
         delay(50);
         setLed(false);
         delay(50);
         count = count - 1;
-    }
+    }*/
+
+    screen->blink();
 }
 
 void handleScanNetworks(HTTPRequest *req, HTTPResponse *res)


### PR DESCRIPTION
Moves the `/json/blink` endpoint to POST, since we're telling the device to do something

Adjusts the timings as recorded here:

https://user-images.githubusercontent.com/11679900/102722988-f7081700-42d2-11eb-8f10-ba44b7d2cea3.mp4

